### PR TITLE
createPatch: Fix git.addConfig() calls, force no gpg sign

### DIFF
--- a/src/createPatch.js
+++ b/src/createPatch.js
@@ -19,10 +19,10 @@ async function createDiff(source, target, patchDir, pkgInfo) {
     await git
       .cwd({ path: path.join(source, "../"), root: true })
       .init()
-      .addConfig("--local", "user.name", "wally-patch-package")
-      .addConfig("--local", "user.email", "wally@pack.age")
-      .addConfig("--local", "core.autocrlf", "false")
-      .addConfig("--local", "commit.gpgsign", "false")
+      .addConfig("user.name", "wally-patch-package", false, "local")
+      .addConfig("user.email", "wally@pack.age", false, "local")
+      .addConfig("core.autocrlf", false, false, "local")
+      .addConfig("commit.gpgsign", false, false, "local")
       .add(["-f", source])
       .commit(["--allow-empty", "-m", "init"]);
 

--- a/src/createPatch.js
+++ b/src/createPatch.js
@@ -22,6 +22,7 @@ async function createDiff(source, target, patchDir, pkgInfo) {
       .addConfig("--local", "user.name", "wally-patch-package")
       .addConfig("--local", "user.email", "wally@pack.age")
       .addConfig("--local", "core.autocrlf", "false")
+      .addConfig("--local", "commit.gpgsign", "false")
       .add(["-f", source])
       .commit(["--allow-empty", "-m", "init"]);
 


### PR DESCRIPTION
`git.addConfig()` takes the following args:
**key**, **value**, **append?**, **scope**

I've changed these calls to follow the proper parameters as defined by the library.

As for the `commit.gpgsign` setting; this basically tells git _not_ to sign commits, because we'll be discarding the commit after creating the patch anyway. Useful just in case the user has this setting toggled on globally.